### PR TITLE
Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1703887061,
+        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1703992652,
+        "narHash": "sha256-C0o8AUyu8xYgJ36kOxJfXIroy9if/G6aJbNOpA5W0+M=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "32f63574c85fbc80e4ba1fbb932cde9619bad25e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "Powerful Minecraft Server Manager CLI";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    gitignore = { url = "github:hercules-ci/gitignore.nix"; flake = false; };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+  flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = nixpkgs.legacyPackages.${system};
+      cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+    in rec {
+      legacyPackages.mcman = pkgs.rustPlatform.buildRustPackage {
+        inherit (cargoToml.package) name version;
+        src = ./.;
+        cargoLock.lockFile = ./Cargo.lock;
+        cargoLock.outputHashes = {
+          "mcapi-0.2.0" = "sha256-wHXA+4DQVQpfSCfJLFuc9kUSwyqo6T4o0PypYdhpp5s=";
+          "pathdiff-0.2.1" = "sha256-+X1afTOLIVk1AOopQwnjdobKw6P8BXEXkdZOieHW5Os=";
+          "rpackwiz-0.1.0" = "sha256-pOotNPIZS/BXiJWZVECXzP1lkb/o9J1tu6G2OqyEnI8=";
+        };
+      };
+      defaultPackage = legacyPackages.mcman;
+    }
+  );
+}


### PR DESCRIPTION
Implements a basic Nix flake with a package:

```
oatmealine@goop-drive ~/p/mcman (main) [1]> nix run
Powerful Minecraft Server Manager CLI

Usage: mcman <COMMAND>

Commands:
  init      Initialize a new mcman server
  build     Build using server.toml configuration
  run       Test the server (stops it when it ends startup)
  dev       Start a development session
  add       Add a plugin/mod/datapack
  pull      Pull files from server/ to config/
  env       Helpers for setting up the environment
  world     Pack or unpack a world [aliases: w]
  import    Importing tools [aliases: i]
  export    Exporting tools
  markdown  Update markdown files with server info [aliases: md]
  download  Download a downloadable [aliases: dl]
  cache     Cache management commands
  info      Show info about the server in console
  version   Show version information [aliases: v]
  help      Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help

To start building servers, try 'mcman init'
```

This lets NixOS users natively pull in the package from this repository.

Currently this does not include a service, dev shell or anything else; meaning you cannot host servers simply using this flake. However, if this is desired, I could begin work on that!

_Note_: I'm unsure if this is something you can fix on your end as I'm not too familiar with Cargo/Rust packages, but `mcapi`, `pathdiff` and `rpackwiz` lack checksum hashes in `Cargo.lock`, which means they have to currently be manually specified in the Nix flake:

```nix
        cargoLock.outputHashes = {
          "mcapi-0.2.0" = "sha256-wHXA+4DQVQpfSCfJLFuc9kUSwyqo6T4o0PypYdhpp5s=";
          "pathdiff-0.2.1" = "sha256-+X1afTOLIVk1AOopQwnjdobKw6P8BXEXkdZOieHW5Os=";
          "rpackwiz-0.1.0" = "sha256-pOotNPIZS/BXiJWZVECXzP1lkb/o9J1tu6G2OqyEnI8=";
        };
```

These will have to be updated to prevent accidental caching issues. However, if the `Cargo.lock` contains them instead, these could be safely removed.