### PR TITLE
refactor: several more cleanups from #55

### DIFF
--- a/src/app/feedback.rs
+++ b/src/app/feedback.rs
@@ -19,10 +19,10 @@ pub enum ProgressPrefix {
 }
 
 macro_rules! enum_to_string {
-    ($input:ident,$($value:ident,)*) => {
+    ($input:ident,$enum_type:ty,$($value:ident,)*) => {
         match $input {
             $(
-                Self::$value => stringify!($value),
+                $enum_type::$value => stringify!($value),
             )*
         }
     };
@@ -32,6 +32,7 @@ impl From<ProgressPrefix> for Cow<'static, str> {
     fn from(val: ProgressPrefix) -> Self {
         Cow::Borrowed(enum_to_string!(
             val,
+            ProgressPrefix,
             Resolving,
             Checking,
             Downloading,

--- a/src/app/feedback.rs
+++ b/src/app/feedback.rs
@@ -22,7 +22,7 @@ macro_rules! enum_to_string {
     ($input:ident,$enum_type:ty,$($value:ident,)*) => {
         match $input {
             $(
-                $enum_type::$value => stringify!($value),
+                <$enum_type>::$value => stringify!($value),
             )*
         }
     };

--- a/src/app/feedback.rs
+++ b/src/app/feedback.rs
@@ -37,7 +37,7 @@ impl From<ProgressPrefix> for Cow<'static, str> {
             Downloading,
             Copying,
             Fetching,
-            Exporting
+            Exporting,
         ))
     }
 }

--- a/src/app/feedback.rs
+++ b/src/app/feedback.rs
@@ -22,7 +22,7 @@ macro_rules! enum_to_string {
     ($input:ident,$($value:ident,)*) => {
         match $input {
             $(
-                Self::$value => $stringify($value),
+                Self::$value => stringify!($value),
             )*
         }
     };

--- a/src/app/hashing.rs
+++ b/src/app/hashing.rs
@@ -1,9 +1,8 @@
 use anyhow::{Context, Result};
-use core::marker::Unpin;
 use digest::{Digest, DynDigest};
 use indicatif::ProgressBar;
 use sha2::Sha256;
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, marker::Unpin, path::PathBuf};
 use tokio::{
     fs::File,
     io::{AsyncRead, AsyncWrite},

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -17,7 +17,10 @@ pub use resolvable::*;
 use crate::model::{AppConfig, Downloadable, Network, Server};
 use crate::sources;
 
-use std::{fmt::{self, Display, Formatter}, env};
+use std::{
+    env,
+    fmt::{self, Display, Formatter},
+};
 
 pub const APP_USER_AGENT: &str = concat!(
     env!("CARGO_PKG_NAME"),
@@ -246,25 +249,25 @@ impl App {
             "denizs_gf" => Some("ily may".to_owned()),
 
             _ => None,
-        }.or_else(|| {
+        }
+        .or_else(|| {
             if let Ok(v) = std::env::var(k) {
                 Some(v)
             } else if k.starts_with("NW_") {
                 if let Some(nw) = &self.network {
                     if k.starts_with("NW_SERVER_") {
-                        let (name, ty) =
-                            k.strip_prefix("NW_SERVER_").unwrap().split_once('_')?;
+                        let (name, ty) = k.strip_prefix("NW_SERVER_").unwrap().split_once('_')?;
 
                         let serv = nw.servers.get(&name.to_lowercase())?;
 
-                            let ip = env::var(format!("IP_{name}"))
-                                .ok()
-                                .or(serv.ip_address.clone())
-                                .unwrap_or("127.0.0.1".to_owned());
+                        let ip = env::var(format!("IP_{name}"))
+                            .ok()
+                            .or(serv.ip_address.clone())
+                            .unwrap_or("127.0.0.1".to_owned());
 
-                            let port = env::var(format!("PORT_{name}"))
-                                .ok()
-                                .unwrap_or(serv.port.to_string());
+                        let port = env::var(format!("PORT_{name}"))
+                            .ok()
+                            .unwrap_or(serv.port.to_string());
 
                         match ty.to_lowercase().as_str() {
                             "ip" => Some(ip),

--- a/src/core/bootstrap.rs
+++ b/src/core/bootstrap.rs
@@ -37,30 +37,26 @@ impl<'a> BuildContext<'a> {
 
         // wtf i have to clone it sorry null
         if let Some(nw) = self.app.network.clone() {
-            self.bootstrap_folder(
-                nw.path.join("groups").join("global").join("config")
-            ).await?;
+            self.bootstrap_folder(nw.path.join("groups").join("global").join("config"))
+                .await?;
 
             if self.app.server.name == nw.proxy {
                 for group_name in &nw.proxy_groups {
-                    self.bootstrap_folder(
-                        nw.path.join("groups").join(group_name).join("config")
-                    ).await?;
+                    self.bootstrap_folder(nw.path.join("groups").join(group_name).join("config"))
+                        .await?;
                 }
             }
 
             if let Some(entry) = nw.servers.get(&self.app.server.name) {
                 for group_name in &entry.groups {
-                    self.bootstrap_folder(
-                        nw.path.join("groups").join(group_name).join("config")
-                    ).await?;
+                    self.bootstrap_folder(nw.path.join("groups").join(group_name).join("config"))
+                        .await?;
                 }
             }
         }
 
-        self.bootstrap_folder(
-            self.app.server.path.join("config")
-        ).await?;
+        self.bootstrap_folder(self.app.server.path.join("config"))
+            .await?;
 
         pb.disable_steady_tick();
         pb.finish_and_clear();
@@ -71,12 +67,12 @@ impl<'a> BuildContext<'a> {
         Ok(())
     }
 
-    pub async fn bootstrap_folder(
-        &mut self,
-        from_path: PathBuf,
-    ) -> Result<()> {
+    pub async fn bootstrap_folder(&mut self, from_path: PathBuf) -> Result<()> {
         if !from_path.exists() {
-            self.app.dbg(format!("skipped bootstrapping {} because it doesnt exist", from_path.display()));
+            self.app.dbg(format!(
+                "skipped bootstrapping {} because it doesnt exist",
+                from_path.display()
+            ));
             return Ok(());
         }
 
@@ -93,8 +89,8 @@ impl<'a> BuildContext<'a> {
             }
 
             let source = entry.path();
-            let diffed_paths = diff_paths(source, &from_path)
-                .ok_or(anyhow!("Cannot diff paths"))?;
+            let diffed_paths =
+                diff_paths(source, &from_path).ok_or(anyhow!("Cannot diff paths"))?;
 
             //pb.set_message(diffed_paths.to_string_lossy().to_string());
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -68,8 +68,7 @@ impl<'a> BuildContext<'a> {
         let server_jar = self.download_server_jar().await?;
         self.app.ci("::endgroup::");
 
-        if !self.skip_stages.contains(&"plugins".to_owned())
-        {
+        if !self.skip_stages.contains(&"plugins".to_owned()) {
             self.download_addons(AddonType::Plugin).await?;
         }
 

--- a/src/hot_reload/config.rs
+++ b/src/hot_reload/config.rs
@@ -22,7 +22,7 @@ pub enum HotReloadAction {
 impl TryFrom<String> for HotReloadAction {
     type Error = anyhow::Error;
 
-    fn try_from(value: String) -> core::result::Result<Self, Self::Error> {
+    fn try_from(value: String) -> std::result::Result<Self, Self::Error> {
         if value.starts_with('/') {
             Ok(Self::RunCommand(
                 value.strip_prefix('/').unwrap().to_string(),

--- a/src/hot_reload/mod.rs
+++ b/src/hot_reload/mod.rs
@@ -265,7 +265,7 @@ impl<'a> DevSession<'a> {
                         }
                         Command::BootstrapGroup(group_name, full_path, rel_path) => {
                             let should = group_name == "global" || self.builder.app.network.as_ref().is_some_and(|nw| {
-                                self.builder.app.server.name == nw.proxy && nw.proxy_groups.contains(&group_name) && nw.servers.get(&self.builder.app.server.name)
+                                (self.builder.app.server.name == nw.proxy && nw.proxy_groups.contains(&group_name)) || nw.servers.get(&self.builder.app.server.name)
                                     .is_some_and(|serv| serv.groups.contains(&group_name))
                             });
 

--- a/src/hot_reload/mod.rs
+++ b/src/hot_reload/mod.rs
@@ -265,18 +265,8 @@ impl<'a> DevSession<'a> {
                         }
                         Command::BootstrapGroup(group_name, full_path, rel_path) => {
                             let should = group_name == "global" || self.builder.app.network.as_ref().is_some_and(|nw| {
-                                if self.builder.app.server.name == nw.proxy {
-                                    if nw.proxy_groups.contains(&group_name) {
-                                        return true;
-                                    }
-                                }
-
-                                if nw.servers.get(&self.builder.app.server.name)
-                                    .is_some_and(|serv| serv.groups.contains(&group_name)) {
-                                    return true;
-                                }
-
-                                false
+                                self.builder.app.server.name == nw.proxy && nw.proxy_groups.contains(&group_name) && nw.servers.get(&self.builder.app.server.name)
+                                    .is_some_and(|serv| serv.groups.contains(&group_name))
                             });
 
                             if should {

--- a/src/hot_reload/mod.rs
+++ b/src/hot_reload/mod.rs
@@ -1,5 +1,12 @@
 use std::{
-    collections::HashSet, env, ffi::OsStr, path::{Component, PathBuf}, process, process::{ExitStatus, Stdio}, sync::{Arc, Mutex}, time::Duration
+    collections::HashSet,
+    env,
+    ffi::OsStr,
+    path::{Component, PathBuf},
+    process,
+    process::{ExitStatus, Stdio},
+    sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -603,7 +610,8 @@ impl<'a> DevSession<'a> {
                             continue;
                         }
 
-                        let g_rel_path = diff_paths(&path, &groups_path).expect("Cannot diff paths");
+                        let g_rel_path =
+                            diff_paths(&path, &groups_path).expect("Cannot diff paths");
 
                         let mut comps = g_rel_path.components();
 
@@ -617,8 +625,12 @@ impl<'a> DevSession<'a> {
 
                         let rel_path = comps.collect::<PathBuf>();
 
-                        tx.blocking_send(Command::BootstrapGroup(group_name.to_string_lossy().into_owned(), path.clone(), rel_path.clone()))
-                            .unwrap();
+                        tx.blocking_send(Command::BootstrapGroup(
+                            group_name.to_string_lossy().into_owned(),
+                            path.clone(),
+                            rel_path.clone(),
+                        ))
+                        .unwrap();
 
                         let guard = config.lock().unwrap();
                         let Some(file) = guard
@@ -694,10 +706,12 @@ impl<'a> DevSession<'a> {
         let mut network_groups_watcher = Self::create_network_groups_watcher(
             cfg_mutex_w.clone(),
             tx.clone(),
-            self.builder.app.network
+            self.builder
+                .app
+                .network
                 .as_ref()
                 .map(|nw| nw.path.join("groups"))
-                .unwrap_or_default()
+                .unwrap_or_default(),
         )?;
 
         if self.hot_reload.is_some() {
@@ -723,8 +737,12 @@ impl<'a> DevSession<'a> {
             )?;
 
             if let Some(nw) = &self.builder.app.network {
-                self.builder.app.log_dev("Watching [network.toml] groups/*/config/**");
-                network_groups_watcher.watcher().watch(&nw.path.join("groups"), RecursiveMode::Recursive)?;
+                self.builder
+                    .app
+                    .log_dev("Watching [network.toml] groups/*/config/**");
+                network_groups_watcher
+                    .watcher()
+                    .watch(&nw.path.join("groups"), RecursiveMode::Recursive)?;
                 networktoml_watcher.watcher().watch(
                     nw.path.join("network.toml").as_path(),
                     RecursiveMode::NonRecursive,

--- a/src/interop/markdown.rs
+++ b/src/interop/markdown.rs
@@ -287,10 +287,8 @@ impl<'a> MarkdownAPI<'a> {
                 let (name, desc) = self.0.spigot().fetch_info(id).await?;
 
                 (
-                    format!(
-                        "[{name}](https://www.spigotmc.org/resources/{id})",
-                        sanitize(&desc)?
-                    ),
+                    format!("[{name}](https://www.spigotmc.org/resources/{id})"),
+                    sanitize(&desc)?,
                     version.clone(),
                 )
             }

--- a/src/interop/markdown.rs
+++ b/src/interop/markdown.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::Write, time::Duration};
+use std::{borrow::Cow, fs::File, io::Write, time::Duration};
 
 use anyhow::{Context, Result};
 use indexmap::IndexMap;
@@ -22,8 +22,7 @@ pub struct MarkdownAPI<'a>(pub &'a App);
 impl<'a> MarkdownAPI<'a> {
     pub fn init_server(&self) -> Result<()> {
         let mut f = File::create(self.0.server.path.join("README.md"))?;
-        let readme_content = include_str!("../../res/default_readme");
-        let readme_content = readme_content
+        let readme_content = include_str!("../../res/default_readme")
             .replace("{SERVER_NAME}", &self.0.server.name)
             .replace(
                 "{ADDON_HEADER}",
@@ -41,9 +40,8 @@ impl<'a> MarkdownAPI<'a> {
 
     pub fn init_network(&self) -> Result<()> {
         let mut f = File::create(self.0.network.as_ref().unwrap().path.join("README.md"))?;
-        let readme_content = include_str!("../../res/default_readme_network");
-        let readme_content =
-            readme_content.replace("{NETWORK_NAME}", &self.0.network.as_ref().unwrap().name);
+        let readme_content = include_str!("../../res/default_readme_network")
+            .replace("{NETWORK_NAME}", &self.0.network.as_ref().unwrap().name);
 
         f.write_all(readme_content.as_bytes())?;
 
@@ -70,6 +68,7 @@ impl<'a> MarkdownAPI<'a> {
             .iter()
             .map(|f| (false, self.0.server.path.join(f)))
             .collect::<Vec<_>>();
+
         if let Some(nw) = &self.0.network {
             files.extend(nw.markdown.files.iter().map(|f| (true, nw.path.join(f))));
         }
@@ -91,6 +90,7 @@ impl<'a> MarkdownAPI<'a> {
                     r"(<!--start:mcman-{id}-->)([\w\W]*)(<!--end:mcman-{id}-->)"
                 ))
                 .unwrap();
+
                 content = re
                     .replace_all(&content, |_caps: &regex::Captures| {
                         format!(
@@ -167,8 +167,8 @@ impl<'a> MarkdownAPI<'a> {
     pub fn table_server(&self) -> MarkdownTable {
         let mut map = IndexMap::new();
 
-        map.insert("Version".to_owned(), self.0.server.mc_version.clone());
-        map.insert("Type".to_owned(), self.0.server.jar.get_md_link());
+        map.insert(Cow::Borrowed("Version"), self.0.server.mc_version.clone());
+        map.insert(Cow::Borrowed("Type"), self.0.server.jar.get_md_link());
 
         map.extend(self.0.server.jar.get_metadata());
 
@@ -182,8 +182,11 @@ impl<'a> MarkdownAPI<'a> {
             for (name, serv) in &nw.servers {
                 let mut map = IndexMap::new();
 
-                map.insert("Name".to_owned(), format!("[`{name}`](./servers/{name}/)"));
-                map.insert("Port".to_owned(), serv.port.to_string());
+                map.insert(
+                    Cow::Borrowed("Name"),
+                    format!("[`{name}`](./servers/{name}/)"),
+                );
+                map.insert(Cow::Borrowed("Port"), serv.port.to_string());
 
                 table.add_from_map(map);
             }
@@ -226,11 +229,18 @@ impl<'a> MarkdownAPI<'a> {
     }
 
     pub async fn table_world(&self, world: &World) -> Result<MarkdownTable> {
-        let mut table = MarkdownTable::with_headers(vec!["Name".to_owned(), "Description".to_owned(), "Version".to_owned()]);
+        let mut table = MarkdownTable::with_headers(vec![
+            Cow::Borrowed("Name"),
+            Cow::Borrowed("Description"),
+            Cow::Borrowed("Version"),
+        ]);
 
         if let Some(dl) = &world.download {
             let mut map = self.fetch_downloadable_info(dl).await?;
-            map.insert("Name".to_owned(), format!("**(World Download)** {}", map["Name"]));
+            map.insert(
+                Cow::Borrowed("Name"),
+                format!("**(World Download)** {}", map["Name"]),
+            );
             table.add_from_map(map);
         }
 
@@ -255,70 +265,58 @@ impl<'a> MarkdownAPI<'a> {
     pub async fn fetch_downloadable_info(
         &self,
         dl: &Downloadable,
-    ) -> Result<IndexMap<String, String>> {
-        let map = match dl {
+    ) -> Result<IndexMap<Cow<'static, str>, String>> {
+        let (name, description, version) = match dl {
             Downloadable::Modrinth { id, version } => {
                 let proj = self.0.modrinth().fetch_project(id).await?;
 
-                IndexMap::from([
-                    (
-                        "Name".to_owned(),
-                        format!("[{}](https://modrinth.com/mod/{})", proj.title, proj.slug),
-                    ),
-                    ("Description".to_owned(), sanitize(&proj.description)?),
-                    ("Version".to_owned(), version.clone()),
-                ])
+                (
+                    format!("[{}](https://modrinth.com/mod/{})", proj.title, proj.slug),
+                    sanitize(&proj.description)?,
+                    version.clone(),
+                )
             }
 
             Downloadable::CurseRinth { id, version } => {
                 let proj = self.0.curserinth().fetch_project(id).await?;
 
-                IndexMap::from([(
-                    "Name".to_owned(),
-                    format!("{} <sup>[CF](https://www.curseforge.com/minecraft/mc-mods/{id}) [CR](https://curserinth.kuylar.dev/mod/{id})</sup>", proj.title, id = proj.slug),
-                ),
-                ("Description".to_owned(), sanitize(&proj.description)?),
-                ("Version".to_owned(), version.clone())])
+                (format!("{} <sup>[CF](https://www.curseforge.com/minecraft/mc-mods/{id}) [CR](https://curserinth.kuylar.dev/mod/{id})</sup>", proj.title, id = proj.slug), sanitize(&proj.description)?, version.clone())
             }
 
             Downloadable::Spigot { id, version } => {
                 let (name, desc) = self.0.spigot().fetch_info(id).await?;
 
-                IndexMap::from([
-                    (
-                        "Name".to_owned(),
-                        format!("[{name}](https://www.spigotmc.org/resources/{id})"),
+                (
+                    format!(
+                        "[{name}](https://www.spigotmc.org/resources/{id})",
+                        sanitize(&desc)?
                     ),
-                    ("Description".to_owned(), sanitize(&desc)?),
-                    ("Version".to_owned(), version.clone()),
-                ])
+                    version.clone(),
+                )
             }
 
             Downloadable::Hangar { id, version } => {
                 let proj = mcapi::hangar::fetch_project(&self.0.http_client, id).await?;
 
-                IndexMap::from([
-                    (
-                        "Name".to_owned(),
-                        format!(
-                            "[{}](https://hangar.papermc.io/{})",
-                            proj.name,
-                            proj.namespace.to_string()
-                        ),
+                (
+                    format!(
+                        "[{}](https://hangar.papermc.io/{})",
+                        proj.name,
+                        proj.namespace.to_string()
                     ),
-                    ("Description".to_owned(), sanitize(&proj.description)?),
-                    ("Version".to_owned(), version.clone()),
-                ])
+                    sanitize(&proj.description)?,
+                    version.clone(),
+                )
             }
 
             Downloadable::GithubRelease { repo, tag, asset } => {
                 let desc = self.0.github().fetch_repo_description(repo).await?;
 
-                IndexMap::from([
-                    ("Name".to_owned(), dl.get_md_link()),
-                    ("Description".to_owned(), sanitize(&desc)?),
-                    ("Version".to_owned(), format!("{tag} / `{asset}`")),
-                ])
+                (
+                    dl.get_md_link(),
+                    sanitize(&desc)?,
+                    format!("{tag} / `{asset}`"),
+                )
             }
 
             Downloadable::Jenkins {
@@ -329,43 +327,37 @@ impl<'a> MarkdownAPI<'a> {
             } => {
                 let desc = self.0.jenkins().fetch_description(url, job).await?;
 
-                IndexMap::from([
-                    ("Name".to_owned(), dl.get_md_link()),
-                    ("Description".to_owned(), sanitize(&desc)?),
-                    ("Version".to_owned(), format!("{build} / `{artifact}`")),
-                ])
+                (
+                    dl.get_md_link(),
+                    sanitize(&desc)?,
+                    format!("{build} / `{artifact}`"),
+                )
             }
 
             Downloadable::Maven {
                 version, artifact, ..
-            } => IndexMap::from([
-                ("Name".to_owned(), artifact.clone()),
-                ("Description".to_owned(), dl.get_md_link()),
-                ("Version".to_owned(), version.clone()),
-            ]),
+            } => (artifact.clone(), dl.get_md_link(), version.clone()),
 
             Downloadable::Url {
                 url,
                 filename,
                 desc,
-            } => IndexMap::from([
-                (
-                    "Name".to_owned(),
-                    format!(
-                        "`{}`",
-                        filename.as_ref().unwrap_or(&"Custom URL".to_owned())
-                    ),
+            } => (
+                format!(
+                    "`{}`",
+                    filename.as_ref().unwrap_or(&"Custom URL".to_owned())
                 ),
-                (
-                    "Description".to_owned(),
-                    desc.as_ref()
-                        .unwrap_or(&"*No description provided*".to_owned())
-                        .clone(),
-                ),
-                ("Version".to_owned(), format!("[URL]({url})")),
-            ]),
+                desc.as_ref()
+                    .unwrap_or(&"*No description provided*".to_owned())
+                    .clone(),
+                format!("[URL]({url})"),
+            ),
         };
 
-        Ok(map)
+        Ok(IndexMap::from([
+            (Cow::Borrowed("Name"), name),
+            (Cow::Borrowed("Description"), description),
+            (Cow::Borrowed("Version"), version),
+        ]))
     }
 }

--- a/src/model/downloadable/markdown.rs
+++ b/src/model/downloadable/markdown.rs
@@ -98,7 +98,7 @@ impl Downloadable {
             ),
         };
 
-        map.insert(Cow::Borrowed("Project/URL"), repo.clone());
+        map.insert(Cow::Borrowed("Project/URL"), project_url.clone());
 
         if let Some(version) = version {
             map.insert(Cow::Borrowed("Version/Release"), version);

--- a/src/model/downloadable/markdown.rs
+++ b/src/model/downloadable/markdown.rs
@@ -1,6 +1,7 @@
 use indexmap::IndexMap;
 
 use crate::{model::Downloadable, sources::jenkins::JenkinsAPI};
+use std::borrow::Cow;
 
 impl Downloadable {
     pub fn get_md_link(&self) -> String {
@@ -52,44 +53,37 @@ impl Downloadable {
         .to_owned()
     }
 
-    pub fn fields_to_map(&self) -> IndexMap<String, String> {
+    pub fn fields_to_map(&self) -> IndexMap<Cow<'static, str>, String> {
         let mut map = IndexMap::new();
 
-        map.insert("Type".to_owned(), self.get_type_name());
+        map.insert(Cow::Borrowed("Type"), self.get_type_name());
 
-        match self {
-            Self::Url { url, filename, .. } => {
-                map.insert("Project/URL".to_owned(), url.clone());
-                map.insert(
-                    "Asset/File".to_owned(),
-                    filename.as_ref().unwrap_or(&String::new()).clone(),
-                );
-            }
+        let (project_url, asset, version) = match self {
+            Self::Url { url, filename, .. } => (
+                url.clone(),
+                Some(filename.as_ref().unwrap_or(&String::new()).clone()),
+                None,
+            ),
 
             Self::GithubRelease { repo, tag, asset } => {
-                map.insert("Project/URL".to_owned(), repo.clone());
-                map.insert("Version/Release".to_owned(), tag.clone());
-                map.insert("Asset/File".to_owned(), asset.clone());
+                (repo.clone(), Some(asset.clone()), Some(tag.clone()))
             }
 
             Self::Modrinth { id, version }
             | Self::CurseRinth { id, version }
             | Self::Hangar { id, version }
-            | Self::Spigot { id, version } => {
-                map.insert("Project/URL".to_owned(), id.clone());
-                map.insert("Version/Release".to_owned(), version.clone());
-            }
+            | Self::Spigot { id, version } => (id.clone(), None, Some(version.clone())),
 
             Self::Jenkins {
                 url,
                 job,
                 build,
                 artifact,
-            } => {
-                map.insert("Project/URL".to_owned(), format!("{job} - ({url})"));
-                map.insert("Version/Release".to_owned(), build.clone());
-                map.insert("Asset/File".to_owned(), artifact.clone());
-            }
+            } => (
+                format!("{job} - ({url})"),
+                Some(artifact.clone()),
+                Some(build.clone()),
+            ),
 
             Self::Maven {
                 url,
@@ -97,11 +91,21 @@ impl Downloadable {
                 artifact,
                 version,
                 filename,
-            } => {
-                map.insert("Project/URL".to_owned(), format!("{group}.{artifact} - ({url})"));
-                map.insert("Version/Release".to_owned(), version.clone());
-                map.insert("Asset/File".to_owned(), filename.clone());
-            }
+            } => (
+                format!("{group}.{artifact} - ({url})"),
+                Some(filename.clone()),
+                Some(version.clone()),
+            ),
+        };
+
+        map.insert(Cow::Borrowed("Project/URL"), repo.clone());
+
+        if let Some(version) = version {
+            map.insert(Cow::Borrowed("Version/Release"), version);
+        }
+
+        if let Some(asset) = asset {
+            map.insert(Cow::Borrowed("Asset/File"), asset);
         }
 
         map

--- a/src/model/network.rs
+++ b/src/model/network.rs
@@ -126,5 +126,3 @@ impl Default for Network {
         }
     }
 }
-
-

--- a/src/model/servertype/meta.rs
+++ b/src/model/servertype/meta.rs
@@ -5,9 +5,9 @@ use std::borrow::Cow;
 
 macro_rules! version_id {
     ($loader:ident, |$id:ident| $id_format:literal) => {
-        match loader.as_str() {
+        match $loader.as_str() {
             "latest" => "*Latest*".to_owned(),
-            id => format!("`{id}`"),
+            $id => format!($id_format),
         }
     };
 

--- a/src/model/servertype/meta.rs
+++ b/src/model/servertype/meta.rs
@@ -1,6 +1,20 @@
 use indexmap::IndexMap;
 
 use super::{Downloadable, ServerType};
+use std::borrow::Cow;
+
+macro_rules! version_id {
+    ($loader:ident, |$id:ident| $id_format:literal) => {
+        match loader.as_str() {
+            "latest" => "*Latest*".to_owned(),
+            id => format!("`{id}`"),
+        }
+    };
+
+    ($loader:ident) => {
+        version_id!($loader, |id| "`{id}`")
+    };
+}
 
 impl ServerType {
     pub fn get_md_link(&self) -> String {
@@ -27,71 +41,42 @@ impl ServerType {
         }
     }
 
-    pub fn get_metadata(&self) -> IndexMap<String, String> {
+    pub fn get_metadata(&self) -> IndexMap<Cow<'static, str>, String> {
         let mut map = IndexMap::new();
 
         match self {
             Self::Fabric { loader, installer } | Self::Quilt { loader, installer } => {
-                map.insert(
-                    "Loader".to_owned(),
-                    match loader.as_str() {
-                        "latest" => "*Latest*".to_owned(),
-                        id => format!("`{id}`"),
-                    },
-                );
+                map.insert(Cow::Borrowed("Loader"), version_id!(loader));
 
                 if installer != "latest" {
-                    map.insert("Installer".to_owned(), format!("`{installer}`"));
+                    map.insert(Cow::Borrowed("Installer"), format!("`{installer}`"));
                 }
             }
 
             Self::NeoForge { loader } | Self::Forge { loader } => {
-                map.insert(
-                    "Loader".to_owned(),
-                    match loader.as_str() {
-                        "latest" => "*Latest*".to_owned(),
-                        id => format!("`{id}`"),
-                    },
-                );
+                map.insert(Cow::Borrowed("Loader"), version_id!(loader));
             }
 
             Self::PaperMC { build, .. } | Self::Purpur { build } => {
-                map.insert(
-                    "Build".to_owned(),
-                    match build.as_str() {
-                        "latest" => "*Latest*".to_owned(),
-                        id => format!("`#{id}`"),
-                    },
-                );
+                map.insert(Cow::Borrowed("Build"), version_id!(build, |id| "`#{id}`"));
             }
 
             Self::Downloadable { inner } => match inner {
                 Downloadable::Jenkins {
                     build, artifact, ..
                 } => {
-                    map.insert(
-                        "Build".to_owned(),
-                        match build.as_str() {
-                            "latest" => "*Latest*".to_owned(),
-                            id => format!("`#{id}`"),
-                        },
-                    );
+                    map.insert(Cow::Borrowed("Build"), version_id!(build, |id| "`#{id}`"));
 
                     if artifact != "first" {
-                        map.insert("Artifact".to_owned(), format!("`{artifact}`"));
+                        map.insert(Cow::Borrowed("Artifact"), format!("`{artifact}`"));
                     }
                 }
+
                 Downloadable::GithubRelease { tag, asset, .. } => {
-                    map.insert(
-                        "Release".to_owned(),
-                        match tag.as_str() {
-                            "latest" => "*Latest*".to_owned(),
-                            id => format!("`{id}`"),
-                        },
-                    );
+                    map.insert(Cow::Borrowed("Release"), version_id!(tag));
 
                     if asset != "first" {
-                        map.insert("Asset".to_owned(), format!("`{asset}`"));
+                        map.insert(Cow::Borrowed("Asset"), format!("`{asset}`"));
                     }
                 }
 

--- a/src/util/md.rs
+++ b/src/util/md.rs
@@ -36,10 +36,6 @@ impl MarkdownTable {
             .map(|header| map.get(header).cloned().unwrap_or_default())
             .collect::<Vec<_>>();
 
-        for header in &self.headers {
-            row.push();
-        }
-
         let hack = self.headers.clone();
 
         for (k, v) in map.into_iter().filter(|(k, _)| !hack.contains(&k)) {

--- a/src/util/md.rs
+++ b/src/util/md.rs
@@ -38,7 +38,7 @@ impl MarkdownTable {
 
         let hack = self.headers.clone();
 
-        for (k, v) in map.into_iter().filter(|(k, _)| !hack.contains(&k)) {
+        for (k, v) in map.into_iter().filter(|(k, _)| !hack.contains(k)) {
             self.headers.push(k);
             row.push(v);
         }


### PR DESCRIPTION
this pull request changes the `IndexMap` key type from `String` to `Cow<'static, str>` as it was frequently used with string literals across the code. (it was originally set as `&'static str` in #55).

other than that, i've also removed some .clone() instances and cleaned up several parts of the code to reduce repetition!