### PR TITLE
Add Unknown dependency type

### DIFF
--- a/src/sources/modrinth.rs
+++ b/src/sources/modrinth.rs
@@ -71,6 +71,7 @@ pub enum DependencyType {
     Incompatible,
     Embedded,
     Unsupported,
+    Unknown,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]


### PR DESCRIPTION
This PR adds the dependency type `Unknown` for a possible response from the Modrinth API.

Fixes #59 