### PR TITLE
Use java 21 by default in docker

### DIFF
--- a/res/default_dockerfile
+++ b/res/default_dockerfile
@@ -3,7 +3,7 @@ WORKDIR /server
 COPY . .
 RUN mcman build
 
-FROM eclipse-temurin:17-alpine
+FROM eclipse-temurin:21-alpine
 USER 1000:1000
 WORKDIR /server
 COPY --from=builder --chown=1000:1000 /server/server/ /server


### PR DESCRIPTION
As of 1.20.5, minecraft now requires java 21