### PR TITLE
Supports recent NeoForge versions (>= MC 1.20.2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ glob = "0.3"
 hex = "0.4"
 indexmap = "2.1"
 indicatif = "0.17"
-mcapi = { git = "https://github.com/ParadigmMC/mcapi.git" }
+mcapi = { git = "https://github.com/ParadigmMC/mcapi.git" , branch = "main" }
 md-5 = "0.10"
 notify-debouncer-full = { version = "0.3" }
 opener = "0.6"

--- a/src/core/scripts.rs
+++ b/src/core/scripts.rs
@@ -16,10 +16,10 @@ impl<'a> BuildContext<'a> {
 
                 StartupMethod::Custom {
                     windows: vec![format!(
-                        "@libraries/net/neoforged/forge/{mcver}-{l}/win_args.txt"
+                        "@libraries/net/neoforged/neoforge/{l}/win_args.txt"
                     )],
                     linux: vec![format!(
-                        "@libraries/net/neoforged/forge/{mcver}-{l}/unix_args.txt"
+                        "@libraries/net/neoforged/neoforge/{l}/unix_args.txt"
                     )],
                 }
             }


### PR DESCRIPTION
Fix to support NeoForge version >= MC 1.20.2
NeoForge has been a fork of Forge since Minecraft 1.20.1, but it became entirely independent in Minecraft version 1.20.2.
Thus, it is reasonable to support NeoForge from version 20.2.88 (MC 1.20.2).