### PR TITLE
make server names case-sensitive

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -258,7 +258,7 @@ impl App {
                     if k.starts_with("NW_SERVER_") {
                         let (name, ty) = k.strip_prefix("NW_SERVER_").unwrap().split_once('_')?;
 
-                        let serv = nw.servers.get(&name.to_lowercase())?;
+                        let serv = nw.servers.get(name)?;
 
                         let ip = env::var(format!("IP_{name}"))
                             .ok()


### PR DESCRIPTION
If you have this in your network.toml:
```toml
[servers.Lobby]
port = 25566
```

`{NW_SERVER_Lobby_PORT}` would not get bootstrapped if the server name was converted to lowercase.