### PR TITLE
Update `upload-artifact`

### DIFF
--- a/res/workflows/test.yml
+++ b/res/workflows/test.yml
@@ -38,13 +38,13 @@ jobs:
       run: |
         mcman run --test
     - name: Archive log
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: latest.log
         path: |
           server/logs/latest.log
     - name: Archive crash reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: steps.test.outcome == 'failure'
       with:
         name: crash


### PR DESCRIPTION
`upload-artifact` v3 [was deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) and has been unusable since January.