### PR TITLE
Make LTO non-default for release, enable explicitly in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup toolchain install stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --release
+      - run: cargo build --profile release-lto
       - uses: actions/upload-artifact@v4
         with:
           name: mcman-${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,16 @@ keywords = [
 categories = ["command-line-utilities", "config"]
 
 [profile.release]
-strip = true
-lto = true
 opt-level = "s"
+strip = true
+
+[profile.release-lto]
+inherits = "release"
+lto = true
+
+[profile.release-lto-thin]
+inherits = "release-lto"
+lto = "thin"
 
 [lints.clippy]
 all = "deny"


### PR DESCRIPTION
LTO is very heavy, and serves little purpose outside of distribution binaries, since mcman isn't as performance-sensitive. thus, axe it :3

(there's still a "release-lto" profile, which the workflow now uses) 
(also a "release-lto-thin" profile for the faster, but slightly worse ThinLTO)

(this will probably be the last in this streak of MRs, sorry for whatever that was :neocat_shocked:)