### PR TITLE
fix: Ensure lockfile has deterministic serialization of unordered hashes

### DIFF
--- a/src/app/hashing.rs
+++ b/src/app/hashing.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use digest::{Digest, DynDigest};
 use indicatif::ProgressBar;
 use sha2::Sha256;
-use std::{collections::HashMap, marker::Unpin, path::PathBuf};
+use std::{collections::BTreeMap, marker::Unpin, path::PathBuf};
 use tokio::{
     fs::File,
     io::{AsyncRead, AsyncWrite},
@@ -13,7 +13,7 @@ use tokio_util::io::ReaderStream;
 use super::{App, ResolvedFile};
 
 impl App {
-    pub fn get_best_hash(hashes: &HashMap<String, String>) -> Option<(String, String)> {
+    pub fn get_best_hash(hashes: &BTreeMap<String, String>) -> Option<(String, String)> {
         hashes
             .get_key_value("sha512")
             .or(hashes.get_key_value("sha256"))

--- a/src/app/resolvable.rs
+++ b/src/app/resolvable.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::BTreeMap};
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -15,7 +15,7 @@ pub struct ResolvedFile {
     pub filename: String,
     pub cache: CacheStrategy,
     pub size: Option<u64>,
-    pub hashes: HashMap<String, String>,
+    pub hashes: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src/interop/mrpack.rs
+++ b/src/interop/mrpack.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use indicatif::{ProgressBar, ProgressFinish, ProgressIterator, ProgressStyle};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     fs::{self, File},
     io::{self, Read, Seek, Write},
     time::Duration,
@@ -213,7 +213,7 @@ pub struct MRPackIndex {
 #[serde(rename_all = "camelCase")]
 pub struct MRPackFile {
     path: String,
-    hashes: HashMap<String, String>,
+    hashes: BTreeMap<String, String>,
     env: Option<Env>,
     file_size: u64,
     downloads: Vec<String>,

--- a/src/interop/packwiz.rs
+++ b/src/interop/packwiz.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     path::{Path, PathBuf},
     time::Duration,
 };
@@ -121,7 +121,7 @@ impl PackwizInterop<'_> {
                                     filename: file.file.split('/').next_back().unwrap().to_owned(),
                                     cache: CacheStrategy::None,
                                     size: None,
-                                    hashes: HashMap::from([(
+                                    hashes: BTreeMap::from([(
                                         match index.hash_format {
                                             HashFormat::Md5 => "md5",
                                             HashFormat::Sha1 => "sha1",

--- a/src/model/downloadable/mod.rs
+++ b/src/model/downloadable/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -100,7 +100,7 @@ impl Resolvable for Downloadable {
                 },
                 cache: CacheStrategy::None,
                 size: None,
-                hashes: HashMap::new(),
+                hashes: BTreeMap::new(),
             }),
             Self::Modrinth { id, version } => app.modrinth().resolve_source(id, version).await,
             Self::CurseRinth { id, version } => app.curserinth().resolve_source(id, version).await,

--- a/src/sources/fabric.rs
+++ b/src/sources/fabric.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::BTreeMap};
 
 use crate::app::{App, CacheStrategy, ResolvedFile};
 use anyhow::{anyhow, Result};
@@ -101,7 +101,7 @@ impl FabricAPI<'_> {
                 path: cached_file_path,
             },
             size: None,
-            hashes: HashMap::new(),
+            hashes: BTreeMap::new(),
         })
     }
 }

--- a/src/sources/github.rs
+++ b/src/sources/github.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Cow,
-    collections::HashMap,
+    collections::BTreeMap,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -239,7 +239,7 @@ impl GithubAPI<'_> {
                 path: cached_file_path,
             },
             size: Some(asset.size),
-            hashes: HashMap::new(),
+            hashes: BTreeMap::new(),
         })
     }
 }

--- a/src/sources/hangar.rs
+++ b/src/sources/hangar.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Cow,
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt::Display,
 };
 
@@ -476,7 +476,7 @@ impl HangarAPI<'_> {
                 path: cached_file_path,
             },
             size: Some(download.get_file_info().size_bytes),
-            hashes: HashMap::from([("sha256".to_owned(), download.get_file_info().sha256_hash)]),
+            hashes: BTreeMap::from([("sha256".to_owned(), download.get_file_info().sha256_hash)]),
         })
     }
 }

--- a/src/sources/jenkins.rs
+++ b/src/sources/jenkins.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::BTreeMap};
 
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
@@ -166,9 +166,9 @@ impl JenkinsAPI<'_> {
                 .iter()
                 .find(|f| f.file_name == artifact.file_name)
             {
-                HashMap::from([("md5".to_owned(), hash.clone())])
+                BTreeMap::from([("md5".to_owned(), hash.clone())])
             } else {
-                HashMap::new()
+                BTreeMap::new()
             },
         })
     }

--- a/src/sources/maven.rs
+++ b/src/sources/maven.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::BTreeMap};
 
 use anyhow::{anyhow, Result};
 
@@ -220,7 +220,7 @@ impl MavenAPI<'_> {
                 path: cached_file_path,
             },
             size: None,
-            hashes: HashMap::new(),
+            hashes: BTreeMap::new(),
         })
     }
 }

--- a/src/sources/modrinth.rs
+++ b/src/sources/modrinth.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap, time::Duration};
+use std::{borrow::Cow, collections::BTreeMap, time::Duration};
 
 use anyhow::{anyhow, Result};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -95,7 +95,7 @@ pub enum ModrinthStatus {
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ModrinthFile {
-    pub hashes: HashMap<String, String>,
+    pub hashes: BTreeMap<String, String>,
     pub url: String,
     pub filename: String,
     pub primary: bool,

--- a/src/sources/papermc.rs
+++ b/src/sources/papermc.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::{BTreeMap, HashMap}};
 
 use anyhow::{anyhow, Result};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -145,7 +145,7 @@ impl PaperMCAPI<'_> {
                 path: cached_file_path,
             },
             size: None,
-            hashes: HashMap::new(),
+            hashes: BTreeMap::new(),
         })
     }
 }

--- a/src/sources/purpur.rs
+++ b/src/sources/purpur.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::BTreeMap};
 
 use anyhow::{anyhow, Result};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -64,7 +64,7 @@ impl PurpurAPI<'_> {
                 path: cached_file_path,
             },
             size: None,
-            hashes: HashMap::from([("md5".to_owned(), resolved_build.md5)]),
+            hashes: BTreeMap::from([("md5".to_owned(), resolved_build.md5)]),
         })
     }
 }

--- a/src/sources/spigot.rs
+++ b/src/sources/spigot.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::BTreeMap};
 
 use anyhow::Result;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -91,7 +91,7 @@ impl SpigotAPI<'_> {
                 path: cached_file_path,
             },
             size: None,
-            hashes: HashMap::new(),
+            hashes: BTreeMap::new(),
         })
     }
 }

--- a/src/sources/vanilla.rs
+++ b/src/sources/vanilla.rs
@@ -1,7 +1,7 @@
 use crate::app::{App, CacheStrategy, ResolvedFile};
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
-use std::{borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::{BTreeMap, HashMap}};
 
 pub struct VanillaAPI<'a>(pub &'a App);
 
@@ -315,7 +315,7 @@ impl VanillaAPI<'_> {
                 path: cached_file_path,
             },
             size: Some(file.size as u64),
-            hashes: HashMap::from([("sha1".to_owned(), file.sha1.clone())]),
+            hashes: BTreeMap::from([("sha1".to_owned(), file.sha1.clone())]),
         })
     }
 }


### PR DESCRIPTION
Since HashMap is unordered, the lockfile produced is non-deterministic because the hashes are serialized in a random order. This is a problem for environments like Nix where we want determinism.

Alternatively, we change `pub hashes` to `BTreeMap` but we'll have update all the callsites, this is the minimal fix. Let me know what you prefer.