### PR TITLE
feature: Add curseforge support as curserinth has 20 item limit and unmaintained

### DIFF
--- a/src/app/from_string.rs
+++ b/src/app/from_string.rs
@@ -22,9 +22,16 @@ impl App {
                         version: version.to_owned(),
                     })
                 }
-                ("cr" | "cf" | "curseforge" | "curserinth", id) => {
+                ("cr" | "curserinth", id) => {
                     let (id, version) = id.split_once(',').unwrap_or((id, "latest"));
                     Ok(Downloadable::CurseRinth {
+                        id: id.to_owned(),
+                        version: version.to_owned(),
+                    })
+                }
+                ("cf" | "curseforge", id) => {
+                    let (id, version) = id.split_once(',').unwrap_or((id, "latest"));
+                    Ok(Downloadable::CurseForge {
                         id: id.to_owned(),
                         version: version.to_owned(),
                     })
@@ -183,7 +190,7 @@ impl App {
                     version.id.clone()
                 };
 
-                Ok(Downloadable::CurseRinth { id, version })
+                Ok(Downloadable::CurseForge { id, version })
             }
 
             // https://www.spigotmc.org/resources/http-requests.101253/

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -332,6 +332,7 @@ impl App {
         maven => MavenAPI,
         jenkins => JenkinsAPI,
         modrinth => ModrinthAPI,
+        curseforge => CurseForgeAPI,
         curserinth => CurserinthAPI,
         neoforge => NeoforgeAPI,
         forge => ForgeAPI,

--- a/src/interop/markdown.rs
+++ b/src/interop/markdown.rs
@@ -283,6 +283,12 @@ impl MarkdownAPI<'_> {
                 (format!("{} <sup>[CF](https://www.curseforge.com/minecraft/mc-mods/{id}) [CR](https://curserinth.kuylar.dev/mod/{id})</sup>", proj.title, id = proj.slug), sanitize(&proj.description)?, version.clone())
             }
 
+            Downloadable::CurseForge { id, version } => {
+                let proj = self.0.curserinth().fetch_project(id).await?;
+
+                (format!("{} <sup>[CF](https://www.curseforge.com/minecraft/mc-mods/{id})</sup>", proj.title, id = proj.slug), sanitize(&proj.description)?, version.clone())
+            }
+
             Downloadable::Spigot { id, version } => {
                 let (name, desc) = self.0.spigot().fetch_info(id).await?;
 

--- a/src/interop/packwiz.rs
+++ b/src/interop/packwiz.rs
@@ -200,10 +200,17 @@ impl PackwizInterop<'_> {
                     version: mr.version.clone(),
                 })
             } else if let Some(cf) = &upd.curseforge {
-                Some(Downloadable::CurseRinth {
-                    id: cf.project_id.to_string(),
-                    version: cf.file_id.to_string(),
-                })
+                if std::env::var("MCMAN_USE_CURSEFORGE").is_ok() {
+                    Some(Downloadable::CurseForge {
+                        id: cf.project_id.to_string(),
+                        version: cf.file_id.to_string(),
+                    })
+                } else {
+                    Some(Downloadable::CurseRinth {
+                        id: cf.project_id.to_string(),
+                        version: cf.file_id.to_string(),
+                    })
+                }
             } else {
                 // TODO clarify
                 self.0.warn("Unknown mod update".to_owned());

--- a/src/model/downloadable/markdown.rs
+++ b/src/model/downloadable/markdown.rs
@@ -36,6 +36,9 @@ impl Downloadable {
             Self::CurseRinth { id, .. } => {
                 format!("`{id}`<sup>[CF](https://www.curseforge.com/minecraft/mc-mods/{id}) [CR](https://curserinth.kuylar.dev/mod/{id})</sup>")
             }
+            Self::CurseForge { id, .. } => {
+                format!("`{id}`<sup>[CF](https://www.curseforge.com/minecraft/mc-mods/{id})</sup>")
+            }
         }
     }
 
@@ -47,6 +50,7 @@ impl Downloadable {
             Self::Hangar { .. } => "Hangar",
             Self::Modrinth { .. } => "Modrinth",
             Self::CurseRinth { .. } => "CurseRinth",
+            Self::CurseForge { .. } => "CurseForge",
             Self::Spigot { .. } => "Spigot",
             Self::Maven { .. } => "Maven",
         }
@@ -71,6 +75,7 @@ impl Downloadable {
 
             Self::Modrinth { id, version }
             | Self::CurseRinth { id, version }
+            | Self::CurseForge { id, version }
             | Self::Hangar { id, version }
             | Self::Spigot { id, version } => (id.clone(), None, Some(version.clone())),
 
@@ -116,6 +121,7 @@ impl Downloadable {
             Self::Modrinth { id, .. } => format!("Modrinth:{id}"),
             Self::Hangar { id, .. } => format!("Hangar:{id}"),
             Self::CurseRinth { id, .. } => format!("CurseRinth:{id}"),
+            Self::CurseForge { id, .. } => format!("CurseForge:{id}"),
             Self::Spigot { id, .. } => format!("Spigot:{id}"),
             Self::GithubRelease { repo, .. } => format!("Github:{repo}"),
             Self::Jenkins { job, .. } => format!("Jenkins:{job}"),

--- a/src/model/downloadable/meta.rs
+++ b/src/model/downloadable/meta.rs
@@ -6,6 +6,7 @@ impl Downloadable {
         match (self, other) {
             (Self::Hangar { id: a, .. }, Self::Hangar { id: b, .. }) if a == b => true,
             (Self::CurseRinth { id: a, .. }, Self::CurseRinth { id: b, .. }) if a == b => true,
+            (Self::CurseForge { id: a, .. }, Self::CurseForge { id: b, .. }) if a == b => true,
             (Self::Modrinth { id: a, .. }, Self::Modrinth { id: b, .. }) if a == b => true,
             (Self::Spigot { id: a, .. }, Self::Spigot { id: b, .. }) if a == b => true,
             (Self::Url { url: a, .. }, Self::Url { url: b, .. }) if a == b => true,

--- a/src/model/downloadable/mod.rs
+++ b/src/model/downloadable/mod.rs
@@ -36,6 +36,13 @@ pub enum Downloadable {
         version: String,
     },
 
+    #[serde(alias = "cf")]
+    CurseForge {
+        id: String,
+        #[serde(default = "latest")]
+        version: String,
+    },
+
     Spigot {
         id: String,
         #[serde(default = "latest")]
@@ -104,6 +111,7 @@ impl Resolvable for Downloadable {
             }),
             Self::Modrinth { id, version } => app.modrinth().resolve_source(id, version).await,
             Self::CurseRinth { id, version } => app.curserinth().resolve_source(id, version).await,
+            Self::CurseForge { id, version } => app.curseforge().resolve_source(id, version).await,
             Self::Spigot { id, version } => app.spigot().resolve_source(id, version).await,
             Self::Hangar { id, version } => app.hangar().resolve_source(id, version).await,
             Self::GithubRelease { repo, tag, asset } => {

--- a/src/sources/curseforge.rs
+++ b/src/sources/curseforge.rs
@@ -1,0 +1,218 @@
+use std::{borrow::Cow, collections::BTreeMap, env};
+
+use anyhow::{anyhow, Result};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+use crate::app::{App, CacheStrategy, ResolvedFile};
+
+static CURSEFORGE_API: &str = "https://api.curseforge.com/v1";
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CurseForgeFile {
+    pub id: u64,
+    pub mod_id: u64,
+    pub is_available: bool,
+    pub display_name: String,
+    pub file_name: String, // 1 = release, 2 = beta, 3 = alpha
+    pub release_type: u8,
+    pub file_status: u8,
+    pub hashes: Vec<CurseForgeHash>,
+    pub file_date: String,
+    pub file_length: u64,
+    pub download_count: u64,
+    pub download_url: Option<String>,
+    pub game_versions: Vec<String>,
+    pub dependencies: Vec<CurseForgeFileDependency>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CurseForgeHash {
+    pub value: String,
+    pub algo: u8, // 1 = sha1, 2 = md5
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CurseForgeFileDependency {
+    pub mod_id: u64,
+    pub relation_type: u8,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CurseForgePagination {
+    pub index: u32,
+    pub page_size: u32,
+    pub result_count: u32,
+    pub total_count: u32,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CurseForgeResponse<T> {
+    pub data: T,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CurseForgeListResponse<T> {
+    pub data: T,
+    pub pagination: CurseForgePagination,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CurseForgeFilesRequest {
+    #[serde(rename = "fileIds")]
+    pub file_ids: Vec<u64>,
+}
+
+pub struct CurseForgeAPI<'a>(pub &'a App);
+
+impl CurseForgeAPI<'_> {
+    fn get_api_key() -> Result<String> {
+        env::var("CURSEFORGE_API_KEY")
+            .map_err(|_| anyhow!("CURSEFORGE_API_KEY environment variable not set."))
+    }
+
+    async fn fetch_api<T: DeserializeOwned>(&self, url: &str) -> Result<T> {
+        let response: T = self
+            .0
+            .http_client
+            .get(url)
+            .header("x-api-key", Self::get_api_key()?)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(response)
+    }
+
+    pub async fn fetch_all_versions(&self, id: &str) -> Result<Vec<CurseForgeFile>> {
+        let mut all_files = Vec::new();
+        let mut index = 0u32;
+        let page_size = 50u32;
+
+        loop {
+            let response: CurseForgeListResponse<Vec<CurseForgeFile>> = self
+                .fetch_api(&format!(
+                    "{CURSEFORGE_API}/mods/{id}/files?index={index}&pageSize={page_size}"
+                ))
+                .await?;
+
+            all_files.extend(response.data);
+
+            if all_files.len() >= response.pagination.total_count as usize {
+                break;
+            }
+
+            index += page_size;
+        }
+
+        Ok(all_files)
+    }
+
+    pub fn filter_versions(&self, versions: &[CurseForgeFile]) -> Vec<CurseForgeFile> {
+        let mc_version = &self.0.server.mc_version;
+        let loader = self.0.server.jar.get_modrinth_name();
+
+        versions
+            .iter()
+            .filter(|v| v.game_versions.iter().any(|gv| gv == mc_version))
+            .filter(|v| {
+                if let Some(loader_name) = loader {
+                    v.game_versions.iter().any(|gv| {
+                        let gv_lower = gv.to_lowercase();
+                        gv_lower == loader_name
+                            || (loader_name == "quilt" && gv_lower == "fabric")
+                    })
+                } else {
+                    true
+                }
+            })
+            .cloned()
+            .collect()
+    }
+
+    pub async fn fetch_versions(&self, id: &str) -> Result<Vec<CurseForgeFile>> {
+        let all_versions = self.fetch_all_versions(id).await?;
+        Ok(self.filter_versions(&all_versions))
+    }
+
+    pub async fn fetch_files_by_ids(&self, file_ids: Vec<u64>) -> Result<Vec<CurseForgeFile>> {
+        let response: CurseForgeResponse<Vec<CurseForgeFile>> = self
+            .0
+            .http_client
+            .post(format!("{CURSEFORGE_API}/mods/files"))
+            .header("x-api-key", Self::get_api_key()?)
+            .json(&CurseForgeFilesRequest { file_ids })
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        Ok(response.data)
+    }
+
+    pub async fn fetch_version(&self, id: &str, version: &str) -> Result<CurseForgeFile> {
+        if version == "latest" {
+            let versions = self.fetch_versions(id).await?;
+            versions.into_iter().next().ok_or_else(|| {
+                anyhow!("No compatible versions for CurseForge project '{id}' (version 'latest')")
+            })
+        } else {
+            let file_id: u64 = version
+                .parse()
+                .map_err(|_| anyhow!("Invalid CurseForge file ID: {version}"))?;
+
+            let files = self.fetch_files_by_ids(vec![file_id]).await?;
+            files
+                .into_iter()
+                .next()
+                .ok_or_else(|| anyhow!("Version '{version}' not found for CurseForge project '{id}'"))
+        }
+    }
+
+    fn convert_hashes(hashes: &[CurseForgeHash]) -> BTreeMap<String, String> {
+        let mut result = BTreeMap::new();
+        for hash in hashes {
+            match hash.algo {
+                1 => {
+                    result.insert("sha1".to_string(), hash.value.clone());
+                }
+                2 => {
+                    result.insert("md5".to_string(), hash.value.clone());
+                }
+                _ => {}
+            }
+        }
+        result
+    }
+
+    pub async fn resolve_source(&self, project_id: &str, version: &str) -> Result<ResolvedFile> {
+        let file = self.fetch_version(project_id, version).await?;
+
+        let download_url = file.download_url.ok_or_else(|| {
+            anyhow!(
+                "CurseForge file {} ({}) has no download URL - may require manual download",
+                file.id,
+                file.display_name
+            )
+        })?;
+
+        let hashes = Self::convert_hashes(&file.hashes);
+        let cached_file_path = format!("{project_id}/{}/{}", file.id, file.file_name);
+
+        Ok(ResolvedFile {
+            url: download_url,
+            filename: file.file_name,
+            cache: CacheStrategy::File {
+                namespace: Cow::Borrowed("curseforge"),
+                path: cached_file_path,
+            },
+            size: Some(file.file_length),
+            hashes,
+        })
+    }
+}

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,3 +1,4 @@
+pub mod curseforge;
 pub mod curserinth;
 pub mod fabric;
 pub mod forge;


### PR DESCRIPTION
I'm new to Minecraft modding and not sure if there's politics or policies involved why we can't implement Curseforge. Let me know, I used the API key that Curserinth is using.

I introduced an env var to switch to curseforge:
```sh
MCMAN_USE_CURSEFORGE=1 CURSEFORGE_API_KEY=<redacted> mcman init --packwiz https://asphodel.cc/packwiz/Ports/Curse/Raspberry-Server/pack.toml
```

I'm having trouble `mcman build` for Raspberry Flavoured which includes a mod of an older MC version. Curserinth limits at 20 items in their implementation: https://github.com/kuylar/curserinth/blob/7fbc142484ca9ca178bfa44dfc6658cd767c2370/CurseRinth/Controllers/V2/VersionsController.cs#L36

If there's no issues, maybe we should just default to the curseforge implementation and keep `curserinth.rs` around for backwards compatibility (and remove the `MCMAN_USE_CURSEFORGE` env var).

So this will fail:
```toml
# server.toml
name = "Test"
mc_version = "1.19.2"

[jar]
type = "forge"
loader = "43.5.1"

[[mods]]
type = "curserinth"
id = "60028"
version = "5320128"
```

But this will succeed with this PR:
```toml
# server.toml - same as above but with:
[[mods]]
type = "curseforge"
id = "60028"
version = "5320128"
```