### PR TITLE
Change Paper release channels to match the API

### DIFF
--- a/src/sources/papermc.rs
+++ b/src/sources/papermc.rs
@@ -32,10 +32,12 @@ pub struct PaperProject {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum PaperChannel {
-    Default,
-    Experimental,
+    Stable,
+    Recommended,
+    Alpha,
+    Beta,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]


### PR DESCRIPTION
Closes #142

As described in https://papermc.io/news/1-21-7/, the PaperMC release channels have changed to:

> 1. `alpha`: Equivalent to the prior `experimental` label
> 2. `beta`: New middle-point for builds that aren't entirely unstable but partially unfinished (e.g., missing config options or, as with the long 1.21.5 phase, missing datafixer changes)
> 3. `stable`: Equivalent to the prior `default` label — **always make sure you stay up-to-date with new builds here, as important fixes and changes continue being pushed**
> 4. `recommended`: **Unused in Paper**, but currently used for Velocity releases. If this ever changes, we will announce it beforehand.

Also switched the serde rename to `SCREAMING_SNAKE_CASE`, cuz that's what they return now I guess.