### PR TITLE
feat(papermc): migrate Paper source to v3 Fill API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,6 +1011,7 @@ checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ digest = "0.10"
 dirs = "5.0"
 glob = "0.3"
 hex = "0.4"
-indexmap = "2.1"
+indexmap = { version = "2.1", features = ["serde"] }
 indicatif = "0.18"
 md-5 = "0.10"
 notify-debouncer-full = { version = "0.3" }

--- a/src/sources/papermc.rs
+++ b/src/sources/papermc.rs
@@ -1,91 +1,89 @@
 use std::{borrow::Cow, collections::{BTreeMap, HashMap}};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
+use indexmap::IndexMap;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::app::{App, CacheStrategy, ResolvedFile};
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct PaperBuildsResponse {
-    pub project_id: String,
-    pub project_name: String,
-    pub version: String,
-    pub builds: Vec<PaperVersionBuild>,
-}
+// PaperMC migrated server distribution off the legacy `api.papermc.io/v2`
+// service onto the new "Fill" API at `fill.papermc.io/v3`. v2 stopped
+// receiving new versions and returns HTTP 404 for Minecraft releases above
+// 1.21.11 (e.g. 26.1.2), whereas v3 has the builds. The v3 shapes differ from
+// v2: builds are returned as a bare newest-first array, build ids live under
+// `id`, the server jar is keyed `server:default` in `downloads`, each download
+// carries `name`/`size`/`url`/`checksums.sha256` (so the URL no longer has to be
+// constructed by hand), and a project's `versions` is an ordered map of
+// version-group -> versions. This module is rewritten to target that v3 shape.
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct PaperVersionBuild {
-    pub build: u64,
+pub struct PaperBuild {
+    pub id: u64,
     pub time: String,
-    pub channel: PaperChannel,
-    pub promoted: bool,
-    pub changes: Vec<PaperChange>,
+    // Retained (e.g. "STABLE") for forward-compat; not currently used for filtering.
+    pub channel: String,
     pub downloads: HashMap<String, PaperDownload>,
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct PaperProject {
-    pub project_id: String,
-    pub project_name: String,
-    pub version_groups: Vec<String>,
-    pub versions: Vec<String>,
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum PaperChannel {
-    Stable,
-    Recommended,
-    Alpha,
-    Beta,
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct PaperChange {
-    pub commit: String,
-    pub summary: String,
-    pub message: String,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PaperDownload {
     pub name: String,
+    pub size: u64,
+    pub url: String,
+    pub checksums: PaperChecksums,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PaperChecksums {
     pub sha256: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PaperProject {
+    // Ordered (newest-first) map of version-group -> list of versions, e.g.
+    // {"26.1": ["26.1.2", "26.1.1"], "1.21": ["1.21.11", ...], ...}.
+    // IndexMap preserves the API's insertion order so "latest" is reliable.
+    pub versions: IndexMap<String, Vec<String>>,
 }
 
 pub struct PaperMCAPI<'a>(pub &'a App);
 
-const PAPERMC_URL: &str = "https://api.papermc.io/v2";
+const PAPERMC_URL: &str = "https://fill.papermc.io/v3";
 const CACHE_DIR: &str = "papermc";
 
+// `project`/`version`/`build` originate from user config and are interpolated
+// into `fill.papermc.io` URL paths, so reject anything outside a conservative
+// allowlist to avoid path traversal / SSRF-adjacent requests.
+fn validate_segment(kind: &str, s: &str) -> Result<()> {
+    if s.is_empty() || s.chars().any(|c| !matches!(c, 'a'..='z'|'A'..='Z'|'0'..='9'|'.'|'-'|'_')) {
+        bail!("Invalid PaperMC {kind}: {s:?}");
+    }
+    Ok(())
+}
+
 impl PaperMCAPI<'_> {
-    pub async fn fetch_api<T: DeserializeOwned + Clone + Serialize>(
-        &self,
-        url: String,
-    ) -> Result<T> {
-        let response = self.0.http_client.get(&url).send().await?;
+    pub async fn fetch_api<T: DeserializeOwned>(&self, url: &str) -> Result<T> {
+        let response = self.0.http_client.get(url).send().await?;
 
         let json: T = response.error_for_status()?.json().await?;
 
         Ok(json)
     }
 
-    pub async fn fetch_versions(&self, project: &str) -> Result<Vec<String>> {
-        let proj = self
-            .fetch_api::<PaperProject>(format!("{PAPERMC_URL}/projects/{project}"))
-            .await?;
-
-        Ok(proj.versions)
+    pub async fn fetch_versions(&self, project: &str) -> Result<PaperProject> {
+        validate_segment("project", project)?;
+        self.fetch_api::<PaperProject>(&format!("{PAPERMC_URL}/projects/{project}"))
+            .await
     }
 
-    pub async fn fetch_builds(&self, project: &str, version: &str) -> Result<PaperBuildsResponse> {
-        let resp = self
-            .fetch_api(format!(
-                "{PAPERMC_URL}/projects/{project}/versions/{version}/builds"
-            ))
-            .await?;
-
-        Ok(resp)
+    pub async fn fetch_builds(&self, project: &str, version: &str) -> Result<Vec<PaperBuild>> {
+        validate_segment("project", project)?;
+        validate_segment("version", version)?;
+        // v3 returns a bare JSON array of builds, newest-first.
+        self.fetch_api(&format!(
+            "{PAPERMC_URL}/projects/{project}/versions/{version}/builds"
+        ))
+        .await
     }
 
     pub async fn fetch_build(
@@ -93,25 +91,30 @@ impl PaperMCAPI<'_> {
         project: &str,
         version: &str,
         build: &str,
-    ) -> Result<PaperVersionBuild> {
-        let builds = self.fetch_builds(project, version).await?;
-        Ok(match build {
-            "latest" => builds
-                .builds
-                .last()
-                .ok_or(anyhow!(
-                    "Latest papermc build for project {project} {version} not found"
-                ))?
-                .clone(),
-            id => builds
-                .builds
-                .iter()
-                .find(|&b| b.build.to_string() == id)
-                .ok_or(anyhow!(
-                    "PaperMC build '{build}' for project {project} {version} not found"
-                ))?
-                .clone(),
-        })
+    ) -> Result<PaperBuild> {
+        match build {
+            // Builds are newest-first, so "latest" is the first element of the
+            // builds array.
+            "latest" => {
+                let builds = self.fetch_builds(project, version).await?;
+                builds
+                    .first()
+                    .ok_or(anyhow!(
+                        "Latest papermc build for project {project} {version} not found"
+                    ))
+                    .cloned()
+            }
+            // Pinned build: hit the single-build endpoint directly.
+            id => {
+                validate_segment("project", project)?;
+                validate_segment("version", version)?;
+                validate_segment("build", id)?;
+                self.fetch_api(&format!(
+                    "{PAPERMC_URL}/projects/{project}/versions/{version}/builds/{id}"
+                ))
+                .await
+            }
+        }
     }
 
     pub async fn resolve_source(
@@ -121,33 +124,43 @@ impl PaperMCAPI<'_> {
         build: &str,
     ) -> Result<ResolvedFile> {
         let version = match version {
-            "latest" => self
-                .fetch_versions(project)
-                .await?
-                .last()
-                .ok_or(anyhow!("No versions"))?
-                .clone(),
+            "latest" => {
+                let proj = self.fetch_versions(project).await?;
+                // `versions` is newest-first; the first group's first entry is
+                // the newest version overall.
+                proj.versions
+                    .values()
+                    .next()
+                    .and_then(|v| v.first())
+                    .ok_or(anyhow!("No versions for papermc project {project}"))?
+                    .clone()
+            }
             id => id.to_owned(),
         };
 
         let resolved_build = self.fetch_build(project, &version, build).await?;
 
-        let download = resolved_build.downloads.get("application")
-            .ok_or(anyhow!("downloads['application'] missing for papermc project {project} {version}, build {build} ({})", resolved_build.build))?;
+        let download = resolved_build.downloads.get("server:default").ok_or(anyhow!(
+            "downloads['server:default'] missing for papermc project {project} {version}, build {build} ({})",
+            resolved_build.id
+        ))?;
+
+        // Cache layout: <namespace>/<project>/<filename>, e.g. papermc/paper/paper-26.1.2-66.jar
         let cached_file_path = format!("{project}/{}", download.name);
 
         Ok(ResolvedFile {
-            url: format!(
-                "{PAPERMC_URL}/projects/{project}/versions/{version}/builds/{}/downloads/{}",
-                resolved_build.build, download.name
-            ),
+            // v3 provides the download URL directly; use it verbatim.
+            url: download.url.clone(),
             filename: download.name.clone(),
             cache: CacheStrategy::File {
                 namespace: Cow::Borrowed(CACHE_DIR),
                 path: cached_file_path,
             },
-            size: None,
-            hashes: BTreeMap::new(),
+            size: Some(download.size),
+            hashes: BTreeMap::from([(
+                String::from("sha256"),
+                download.checksums.sha256.clone(),
+            )]),
         })
     }
 }


### PR DESCRIPTION
# Migrate PaperMC source from the deprecated v2 API to the v3 Fill API

Closes #146

## Problem

`src/sources/papermc.rs` resolves Paper builds through `https://api.papermc.io/v2`. PaperMC has frozen v2: its version list tops out at `1.21.11`, and `GET v2/projects/paper/versions/26.1.2/builds` returns `404 {"error":"Version not found."}`. Every modern Minecraft version (the `26.x` scheme onward) lives only on the new Fill API at `https://fill.papermc.io/v3`, so `mcman build` cannot resolve a Paper jar for any current MC version. Full evidence in #146.

## Change

Rewrites `src/sources/papermc.rs` to target the v3 Fill API. The v3 response shapes differ from v2, so the structs and `resolve_source` are reworked, not just the base URL:

- **Base URL** `api.papermc.io/v2` → `fill.papermc.io/v3`.
- **Builds** are returned as a bare, newest-first JSON array (v2 wrapped them in an object, oldest-first). `"latest"` is now the first element; a pinned build hits the single-build endpoint `/builds/{id}` directly.
- **Build id** moved from `build` (u64) to `id` (u64).
- **Server jar** is keyed `server:default` in `downloads` (was `application`).
- **Download URL** is provided directly as `downloads["server:default"].url`, so it's used verbatim instead of being hand-constructed from the API path.
- **Versions** is now an ordered (newest-first) map of version-group → versions, deserialized into an `IndexMap` to preserve API order so `"latest"` is reliable. (Adds the `serde` feature to the existing `indexmap` dependency.)
- **`ResolvedFile` now carries `size` and the sha256** from the v3 `downloads[...].checksums.sha256` (v2 left both empty).
- Drops v2-only fields that v3 does not provide and the resolver never used: the `PaperChannel` enum, `version_groups`, `promoted`, and `changes`/`commits`. `channel` is retained as a plain `String` for forward-compat but is not used for filtering.
- Adds a `validate_segment()` allowlist on the user-supplied `project` / `version` / `build` values before they are interpolated into request URLs.

## Testing

- `cargo check` passes.
- `cargo clippy --all-features` produces **no findings in `papermc.rs`**. (The repo currently has pre-existing clippy errors on `main` in unrelated files - `init/mod.rs`, `packwiz.rs`, `jenkins.rs`. This PR doesn't touch those.)
- End-to-end: `mcman build` against `mc_version = "26.1.2"` resolves the Paper jar and assembles a full 20-plugin server with correct loader-filtering. Verified in production on a live 26.1.2 server for several weeks.

## Notes for the reviewer

- **Clean cutover, no v2 fallback.** The Fill API serves the full historical version list, so legacy MC versions (≤ `1.21.11`) resolve through v3 as well. Happy to add a v2 fallback path instead if you'd prefer to keep the old endpoint for older servers.
- Single commit, based on current `main` (`2665efb`).